### PR TITLE
More granular trailing comma options

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,18 @@ prettier.format(source, {
 
   // If true, will use single instead of double quotes
   singleQuote: false,
-
-  // Controls the printing of trailing commas wherever possible
+  
+  // Controls the printing of trailing commas in objects and arrays
   trailingComma: false,
+
+  // Controls the printing of trailing commas in js module imports
+  trailingCommaImports: false,
+
+  // Controls the printing of trailing commas in js module exports
+  trailingCommaExports: false,
+
+  // Controls the printing of trailing commas in function call arguments
+  trailingCommaArgs: false,
 
   // Controls the printing of spaces inside arrays
   bracketSpacing: false,

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -15,6 +15,9 @@ const argv = minimist(process.argv.slice(2), {
     "use-tabs",
     "single-quote",
     "trailing-comma",
+    "trailing-comma-imports",
+    "trailing-comma-exports",
+    "trailing-comma-arguments",
     "bracket-spacing",
     "braces-spacing",
     "jsx-fb-close-tag",
@@ -59,7 +62,10 @@ if (argv["help"] || !filepatterns.length && !stdin) {
       "  --use-tabs               Indent lines with tabs instead of spaces. Defaults to false.\n" +
       "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
       "  --single-quote           Use single quotes instead of double.\n" +
-      "  --trailing-comma         Print trailing commas wherever possible.\n" +
+      "  --trailing-comma         Print trailing commas in objects and arrays.\n" +
+      "  --trailing-comma-imports Print trailing commas in js module imports.\n" +
+      "  --trailing-comma-exports Print trailing commas in js module exports.\n" +
+      "  --trailing-comma-args    Print trailing commas in function call arguments.\n" +
       "  --bracket-spacing        Put spaces between [brackets]. Defaults to false.\n" +
       "  --braces-spacing         Put spaces between {braces}. Defaults to true.\n" +
       "  --jsx-fb-close-tag       Close JSX tags on the last attribute instead of new line. Defaults to false.\n" +

--- a/src/options.js
+++ b/src/options.js
@@ -12,8 +12,14 @@ var defaults = {
   printWidth: 80,
   // If true, will use single instead of double quotes
   singleQuote: false,
-  // Controls the printing of trailing commas wherever possible
+  // Controls the printing of trailing commas in objects and arrays
   trailingComma: false,
+  // Controls the printing of trailing commas in js module imports
+  trailingCommaImports: false,
+  // Controls the printing of trailing commas in js module exports
+  trailingCommaExports: false,
+  // Controls the printing of trailing commas in function call arguments
+  trailingCommaArgs: false,
   // Controls the printing of spaces inside arrays
   bracketSpacing: false,
   // Controls the printing of spaces inside objects

--- a/src/printer.js
+++ b/src/printer.js
@@ -463,7 +463,7 @@ function genericPrintNoParens(path, options, print) {
                     join(concat([",", line]), grouped)
                   ])
                 ),
-                ifBreak(options.trailingComma ? "," : ""),
+                ifBreak(options.trailingCommaImports ? "," : ""),
                 options.bracesSpacing ? line : softline,
                 "}"
               ])
@@ -1799,7 +1799,7 @@ function printArgumentsList(path, options, print) {
                 1,
                 concat([line, join(concat([",", line]), printed)])
               ),
-              options.trailingComma ? "," : "",
+              options.trailingCommaArgs ? "," : "",
               line,
               ")"
             ]),
@@ -1818,7 +1818,7 @@ function printArgumentsList(path, options, print) {
         1,
         concat([softline, join(concat([",", line]), printed)])
       ),
-      ifBreak(options.trailingComma ? "," : ""),
+      ifBreak(options.trailingCommaArgs ? "," : ""),
       softline,
       ")"
     ]),
@@ -1864,7 +1864,7 @@ function printFunctionParams(path, print, options) {
       1,
       concat([softline, join(concat([",", line]), printed)])
     ),
-    ifBreak(canHaveTrailingComma && options.trailingComma ? "," : ""),
+    ifBreak(canHaveTrailingComma && options.trailingCommaArgs ? "," : ""),
     softline,
     ")"
   ]);
@@ -1975,7 +1975,7 @@ function printExportDeclaration(path, options, print) {
                   join(concat([",", line]), path.map(print, "specifiers"))
                 ])
               ),
-              ifBreak(options.trailingComma ? "," : ""),
+              ifBreak(options.trailingCommaExports ? "," : ""),
               options.bracesSpacing ? line : softline,
               "}"
             ])

--- a/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,42 @@
+exports[`test export.js 1`] = `
+"export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \"exports\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  value1,
+  value2 as value2_renamed,
+  value3,
+  value4 as value4_renamed,
+  value5
+} from \"exports\";
+"
+`;
+
+exports[`test export.js 2`] = `
+"export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \"exports\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  value1,
+  value2 as value2_renamed,
+  value3,
+  value4 as value4_renamed,
+  value5
+} from \"exports\";
+"
+`;
+
+exports[`test export.js 3`] = `
+"export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \"exports\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export {
+  value1,
+  value2 as value2_renamed,
+  value3,
+  value4 as value4_renamed,
+  value5,
+} from \"exports\";
+"
+`;
+
 exports[`test function-calls.js 1`] = `
 "const a = (param1, param2, param3) => {}
 
@@ -49,6 +88,37 @@ a(\"value\", \"value2\", \"value3\");
 a(
   \"a-long-value\",
   \"a-really-really-long-value\",
+  \"a-really-really-really-long-value\"
+);
+
+a(
+  \"value\",
+  \"value2\",
+  a(\"long-nested-value\", \"long-nested-value2\", \"long-nested-value3\")
+);
+"
+`;
+
+exports[`test function-calls.js 3`] = `
+"const a = (param1, param2, param3) => {}
+
+a(\'value\', \'value2\', \'value3\');
+
+a(
+  \'a-long-value\',
+  \'a-really-really-long-value\',
+  \'a-really-really-really-long-value\',
+);
+
+a(\'value\', \'value2\', a(\'long-nested-value\', \'long-nested-value2\', \'long-nested-value3\'));
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const a = (param1, param2, param3) => {};
+
+a(\"value\", \"value2\", \"value3\");
+
+a(
+  \"a-long-value\",
+  \"a-really-really-long-value\",
   \"a-really-really-really-long-value\",
 );
 
@@ -57,6 +127,87 @@ a(
   \"value2\",
   a(\"long-nested-value\", \"long-nested-value2\", \"long-nested-value3\"),
 );
+"
+`;
+
+exports[`test import.js 1`] = `
+"import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \'.\';
+import {fitsIn, oneLine} from \'.\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \".\";
+import { fitsIn, oneLine } from \".\";
+"
+`;
+
+exports[`test import.js 2`] = `
+"import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \'.\';
+import {fitsIn, oneLine} from \'.\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \".\";
+import { fitsIn, oneLine } from \".\";
+"
+`;
+
+exports[`test import.js 3`] = `
+"import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from \'.\';
+import {fitsIn, oneLine} from \'.\';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns,
+} from \".\";
+import { fitsIn, oneLine } from \".\";
 "
 `;
 
@@ -108,6 +259,53 @@ const aLong = {
 `;
 
 exports[`test object.js 2`] = `
+"const a = {
+  b: true,
+  c: {
+    c1: \'hello\'
+  },
+  d: false
+};
+
+const aLong = {
+  bHasALongName: \'a-long-value\',
+  cHasALongName: {
+    c1: \'a-really-long-value\',
+    c2: \'a-really-really-long-value\',
+  },
+  dHasALongName: \'a-long-value-too\'
+};
+
+const aLong = {
+  dHasALongName: \'a-long-value-too\',
+  eHasABooleanExpression: a === a,
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const a = {
+  b: true,
+  c: {
+    c1: \"hello\",
+  },
+  d: false,
+};
+
+const aLong = {
+  bHasALongName: \"a-long-value\",
+  cHasALongName: {
+    c1: \"a-really-long-value\",
+    c2: \"a-really-really-long-value\",
+  },
+  dHasALongName: \"a-long-value-too\",
+};
+
+const aLong = {
+  dHasALongName: \"a-long-value-too\",
+  eHasABooleanExpression: a === a,
+};
+"
+`;
+
+exports[`test object.js 3`] = `
 "const a = {
   b: true,
   c: {

--- a/tests/trailing_comma/export.js
+++ b/tests/trailing_comma/export.js
@@ -1,0 +1,1 @@
+export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from "exports";

--- a/tests/trailing_comma/import.js
+++ b/tests/trailing_comma/import.js
@@ -1,0 +1,11 @@
+import {
+  runTaskForChanged,
+  description,
+  someOtherLabel,
+  thatMakes,
+  itGo,
+  multiLine,
+  andMore,
+  soWeCanGetItTo80Columns
+} from '.';
+import {fitsIn, oneLine} from '.';

--- a/tests/trailing_comma/jsfmt.spec.js
+++ b/tests/trailing_comma/jsfmt.spec.js
@@ -1,3 +1,10 @@
 run_spec(__dirname);
 
 run_spec(__dirname, { trailingComma: true });
+
+run_spec(__dirname, {
+  trailingComma: true,
+  trailingCommaImports: true,
+  trailingCommaExports: true,
+  trailingCommaArgs: true
+});


### PR DESCRIPTION
Separate options to have trailing commas in the following places:

- in objects and arrays
- in js module imports
- in js module exports
- in function call arguments