### PR TITLE
This will add the `jsxAttributesIndent` option.

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -27,6 +27,7 @@ const argv = minimist(process.argv.slice(2), {
     "break-before-else",
     "flatten-ternaries",
     "jsx-bracket-same-line",
+    "jsx-attributes-indent",
     "align-object-properties",
     "space-empty-fn",
     // The supports-color package (a sub sub dependency) looks directly at
@@ -182,6 +183,7 @@ const options = {
   breakBeforeElse: argv["break-before-else"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
+  jsxAttributesIndent: argv["jsx-attributes-indent"],
   noSpaceEmptyFn: !argv["space-empty-fn"],
   filepath: argv["stdin-filepath"],
   trailingComma: getTrailingComma(),
@@ -272,6 +274,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "  --flatten-ternaries      Format ternaries in a flat style.\n" +
       "  --break-before-else      Put `else` clause in a new line.\n" +
       "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
+      "  --jsx-attributes-indent  Indent multiline attributes with a single space.\n" +
       "  --trailing-comma <none|es5|all>\n" +
       "                           Print trailing commas wherever possible. Defaults to none.\n" +
       "                           You can customize with a comma separated list. 'all' is equivalent to:\n" +

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,7 @@ function require(path) { return window[path.replace(/.+-/, '')]; }
     <label><input type="checkbox" id="singleQuote"></input> singleQuote</label>
     <label><input type="checkbox" id="bracketSpacing" checked></input> bracketSpacing</label>
     <label><input type="checkbox" id="jsxBracketSameLine"></input> jsxBracketSameLine</label>
+    <label><input type="checkbox" id="jsxAttributesIndent"></input> jsxAttributesIndent</label>
     <label>trailingComma <select id="trailingComma"><option value="none">none</option><option value="es5">es5</option><option value="all">all</option></select></label>
     <label>parser <select id="parser"><option value="babylon">babylon</option><option value="flow">flow</option><option value="typescript">typescript</option><option value="postcss">postcss</option></select></label>
     <span style="flex: 1"></span>
@@ -123,7 +124,7 @@ function require(path) { return window[path.replace(/.+-/, '')]; }
 
 <script id="code">
 (function () {
-var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'jsxBracketSameLine', 'parser', 'semi', 'useTabs', 'doc'];
+var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'jsxBracketSameLine', 'jsxAttributesIndent', 'parser', 'semi', 'useTabs', 'doc'];
 function setOptions(options) {
   OPTIONS.forEach(function(option) {
     var elem = document.getElementById(option);

--- a/docs/index.js
+++ b/docs/index.js
@@ -4393,16 +4393,18 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
+      const attributes = concat$2(
+        path.map(attr => concat$2([line$1, print(attr)]), "attributes")
+      );
+
       return group$1(
         concat$2([
           "<",
           path.call(print, "name"),
           concat$2([
-            indent$2(
-              concat$2(
-                path.map(attr => concat$2([line$1, print(attr)]), "attributes")
-              )
-            ),
+            options.jsxAttributesIndent
+              ? align$1({ forceSpace: true }, attributes)
+              : indent$2(attributes),
             n.selfClosing ? line$1 : options.jsxBracketSameLine ? ">" : softline$1
           ]),
           n.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"
@@ -7712,6 +7714,17 @@ function makeAlign(ind, n) {
     };
   }
 
+  if (isNaN(n) && n.forceSpace) {
+    return {
+      indent: ind.indent,
+      align: {
+        spaces: ind.align.spaces,
+        tabs: ind.align.tabs,
+        forceSpace: ind.indent
+      }
+    };
+  }
+
   return {
     indent: ind.indent,
     align: {
@@ -8077,9 +8090,14 @@ function printDocToString$1(doc, options) {
                 }
 
                 const length = ind.indent * options.tabWidth + ind.align.spaces;
-                const indentString = options.useTabs
+                let indentString = options.useTabs
                   ? "\t".repeat(ind.indent + ind.align.tabs)
                   : " ".repeat(length);
+
+                if (ind.align.forceSpace !== undefined && ind.align.forceSpace === ind.indent) {
+                  indentString += " ";
+                }
+
                 out.push(newLine + indentString);
                 pos = length;
               }
@@ -11853,6 +11871,7 @@ const defaults = {
   trailingComma: "none",
   bracketSpacing: true,
   jsxBracketSameLine: false,
+  jsxAttributesIndent: false,
   parser: "babylon",
   semi: true
 };

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -34,12 +34,6 @@ function align(n, contents) {
   return { type: "align", contents, n };
 }
 
-function alignSpaces(n, contents) {
-  assertDoc(contents);
-
-  return { type: "align-spaces", contents, n };
-}
-
 function group(contents, opts) {
   opts = opts || {};
 

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -36,6 +36,17 @@ function makeAlign(ind, n) {
     };
   }
 
+  if (isNaN(n) && n.forceSpace) {
+    return {
+      indent: ind.indent,
+      align: {
+        spaces: ind.align.spaces,
+        tabs: ind.align.tabs,
+        forceSpace: ind.indent
+      }
+    };
+  }
+
   return {
     indent: ind.indent,
     align: {
@@ -404,9 +415,14 @@ function printDocToString(doc, options) {
                 }
 
                 const length = ind.indent * options.tabWidth + ind.align.spaces;
-                const indentString = options.useTabs
+                let indentString = options.useTabs
                   ? "\t".repeat(ind.indent + ind.align.tabs)
                   : " ".repeat(length);
+
+                if (ind.align.forceSpace !== undefined && ind.align.forceSpace === ind.indent) {
+                  indentString += " ";
+                }
+
                 out.push(newLine + indentString);
                 pos = length;
               }

--- a/src/options.js
+++ b/src/options.js
@@ -43,6 +43,7 @@ const defaults = {
   flattenTernaries: false,
   breakBeforeElse: false,
   jsxBracketSameLine: false,
+  jsxAttributesIndent: false,
   alignObjectProperties: false,
   noSpaceEmptyFn: false,
   parser: "babylon",

--- a/src/printer.js
+++ b/src/printer.js
@@ -1698,16 +1698,18 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
+      const attributes = concat(
+        path.map(attr => concat([line, print(attr)]), "attributes")
+      );
+
       return group(
         concat([
           "<",
           path.call(print, "name"),
           concat([
-            indent(
-              concat(
-                path.map(attr => concat([line, print(attr)]), "attributes")
-              )
-            ),
+            options.jsxAttributesIndent
+              ? align({ forceSpace: true }, attributes)
+              : indent(attributes),
             n.selfClosing ? line : options.jsxBracketSameLine ? ">" : softline
           ]),
           n.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"

--- a/tests/jsx-attributes-indent/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-attributes-indent/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue,
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+ onEnter={this.onEnter}
+ onLeave={this.onLeave}
+ onChange={this.onChange}
+ initialValue={this.state.initialValue}
+ bigObject={{
+  test: value,
+  test2: otherValue
+ }}
+ ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;
+
+exports[`test.js 2`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue,
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;
+
+exports[`test.js 3`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue,
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+ onEnter={this.onEnter}
+ onLeave={this.onLeave}
+ onChange={this.onChange}
+ initialValue={this.state.initialValue}
+ bigObject={{
+	test: value,
+	test2: otherValue
+ }}
+ ignoreStuff={true}
+>
+	<div>and the children go here</div>
+	<div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;
+
+exports[`test.js 4`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue,
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+	onEnter={this.onEnter}
+	onLeave={this.onLeave}
+	onChange={this.onChange}
+	initialValue={this.state.initialValue}
+	bigObject={{
+		test: value,
+		test2: otherValue
+	}}
+	ignoreStuff={true}
+>
+	<div>and the children go here</div>
+	<div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;

--- a/tests/jsx-attributes-indent/jsfmt.spec.js
+++ b/tests/jsx-attributes-indent/jsfmt.spec.js
@@ -1,0 +1,4 @@
+run_spec(__dirname, { jsxAttributesIndent: true, useTabs: false }, ["typescript"]);
+run_spec(__dirname, { jsxAttributesIndent: false, useTabs: false }, ["typescript"]);
+run_spec(__dirname, { jsxAttributesIndent: true, useTabs: true }, ["typescript"]);
+run_spec(__dirname, { jsxAttributesIndent: false, useTabs: true }, ["typescript"]);

--- a/tests/jsx-attributes-indent/test.js
+++ b/tests/jsx-attributes-indent/test.js
@@ -1,0 +1,14 @@
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  bigObject={{
+    test: value,
+    test2: otherValue,
+  }}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>


### PR DESCRIPTION
Indenting attributes with a single space provides much more readable code, as the boundaries between attributes, child nodes and closing tags are apparent, and it scales well for large amount of tags:

```html
<div
 attr1="my attr"
 attr2="my other attr">
    <child />
    <child
     nestedAttr2="test"
     nestedAttr3="test" />
</div>
```

The name of the option is not the best though, we can certainly update that.

I got redirected to this project since the idea was not taken all that
heartly in the prettier proper. You can take a look at the discussion
there: https://github.com/prettier/prettier/pull/2082