### PR TITLE
Add support for --no-indent-chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ conforms to a consistent style. (See this [blog post](http://jlongster.com/A-Pre
   + [Trailing Commas](#trailing-commas)
   + [Bracket Spacing](#bracket-spacing)
   + [JSX Brackets](#jsx-brackets)
+  + [Indent Chains](#indent-chains)
   + [Range](#range)
   + [Parser](#parser)
   + [Filepath](#filepath)
@@ -402,6 +403,7 @@ Prettier ships with a handful of customizable format options, usable in both the
 | **Bracket Spacing** - Print spaces between brackets in array literals.<br /><br />Valid options: <br /> - `true` - Example: `[ foo: bar ]` <br /> - `false` - Example: `[foo: bar]` | `true` | CLI: `--no-bracket-spacing` <br/>API: `bracketSpacing: <bool>` |
 | **Braces Spacing** - Print spaces between braces in object literals.<br /><br />Valid options: <ul><li>`true` - Example: `{ foo: bar }`</li><li>`false` - Example: `{foo: bar}`</li> | `true` | CLI: `--no-braces-spacing` <br />API: `bracesSpacing: <bool>` |
 | **JSX Brackets on Same Line** - Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line | `false` | CLI: `--jsx-bracket-same-line` <br />API: `jsxBracketSameLine: <bool>` |
+| **Indent Chains** - Indent chained calls.<br /><br />Valid options: <ul><li>`true` - Indent chained calls.</li><li>`false` - Do not indent chained calls.</li> | `true` | CLI: `--no-indent-chains` <br />API: `indentChains: <bool>` |
 | **Align Object Properties** - Align colons in multiline object literals. Does nothing if object has computed property names. | `false` | CLI: `--align-object-properties` <br/>API: `alignObjectProperties: <bool>` |
 | **No Space in Empty Function** - Omit space before empty anonymous function body.<br /><br />Valid options: <br /> - `true` <br /> - `false` | `false` | CLI: `--no-space-empty-fn` <br/>API: `noSpaceEmptyFn: <bool>` |
 | **Space before Function Paren** - Put a [space before function parenthesis](http://eslint.org/docs/rules/space-before-function-paren#always).<br /><br />Valid options: <br /> - `true` <br /> - `false` | `false` | CLI: `--space-before-function-paren` <br/>API: `spaceBeforeFunctionParen: <bool>` |
@@ -606,6 +608,17 @@ Put the `>` of a multi-line JSX element at the end of the last line instead of b
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>`
+
+### Indent Chains
+Print indents at the start of chained calls.
+
+Valid options:
+ * `true` - Print indents.
+ * `false` - Do not print indents.
+
+Default | CLI Override | API Override
+--------|--------------|-------------
+`true` | `--no-indent-chains` | `indentChains: <bool>`
 
 ### Range
 Format only a segment of a file.

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -34,6 +34,7 @@ const booleanOptionNames = [
   "space-before-function-paren",
   "jsx-single-quote",
   "jsx-bracket-same-line",
+  "indent-chains",
   // Deprecated in 0.0.10
   "flow-parser"
 ];
@@ -128,6 +129,7 @@ function getOptionsForFile(filePath) {
           {
             semi: true,
             "bracket-spacing": true,
+            "indent-chains": true,
             parser: "babylon"
           },
           dashifyObject(options)
@@ -164,6 +166,7 @@ function getOptions(argv) {
     spaceBeforeFunctionParen: argv["space-before-function-paren"],
     jsxSingleQuote: argv["jsx-single-quote"],
     jsxBracketSameLine: argv["jsx-bracket-same-line"],
+    indentChains: argv["indent-chains"],
     filepath: argv["stdin-filepath"],
     trailingComma: getTrailingComma(argv),
     parser: getParserOption(argv)
@@ -330,6 +333,7 @@ if (
       "  --flatten-ternaries      Format ternaries in a flat style.\n" +
       "  --break-before-else      Put `else` clause in a new line.\n" +
       "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
+      "  --no-indent-chains       Do not indent chained calls.\n" +
       "  --trailing-comma <none|es5|all>\n" +
       "                           Print trailing commas wherever possible. Defaults to none.\n" +
       "                           You can customize with a comma separated list. 'all' is equivalent to:\n" +

--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -90,6 +90,18 @@ Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>`
 
+## Indent Chains
+Print indents at the start of chained calls.
+
+Valid options:
+ * `true` - Print indents.
+ * `false` - Do not print indents.
+
+Default | CLI Override | API Override
+--------|--------------|-------------
+`true` | `--no-indent-chains` | `indentChains: <bool>`
+
+
 ## Range
 Format only a segment of a file.
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "postcss-values-parser": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
     "strip-bom": "3.0.0",
     "typescript": "2.5.0-dev.20170617",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#7c38401aa1452e6cc493151b8ab3a591e4d5e74a"
+    "typescript-eslint-parser": "14.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/options.js
+++ b/src/options.js
@@ -99,7 +99,6 @@ function normalize(options) {
     delete normalized.useFlowParser;
   }
 
-  debugger;
   Object.keys(defaults).forEach(k => {
     if (normalized[k] == null) {
       normalized[k] = defaults[k];

--- a/src/options.js
+++ b/src/options.js
@@ -44,6 +44,7 @@ const defaults = {
   flattenTernaries: false,
   breakBeforeElse: false,
   jsxBracketSameLine: false,
+  indentChains: true,
   alignObjectProperties: false,
   noSpaceEmptyFn: false,
   parser: "babylon",
@@ -98,6 +99,7 @@ function normalize(options) {
     delete normalized.useFlowParser;
   }
 
+  debugger;
   Object.keys(defaults).forEach(k => {
     if (normalized[k] == null) {
       normalized[k] = defaults[k];

--- a/src/printer.js
+++ b/src/printer.js
@@ -3669,9 +3669,8 @@ function printMemberChain(path, options, print) {
     if (groups.length === 0) {
       return "";
     }
-    return indent(
-      group(concat([hardline, join(hardline, groups.map(printGroup))]))
-    );
+    const answer = group(concat([hardline, join(hardline, groups.map(printGroup))]));
+    return options.indentChains ? indent(answer) : answer;
   }
 
   const printedGroups = groups.map(printGroup);

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -263,6 +263,7 @@
           <label><input type="checkbox" id="singleQuote"></input> --single-quote</label>
           <label><input type="checkbox" data-inverted id="bracketSpacing"></input> --no-bracket-spacing</label>
           <label><input type="checkbox" id="jsxBracketSameLine"></input> --jsx-bracket-same-line</label>
+          <label><input type="checkbox" data-inverted id="indentChains"></input> --no-indent-chains</label>
         </div>
         <div class="options last">
           <label>--trailing-comma <select id="trailingComma"><option value="none">none</option><option value="es5">es5</option><option value="all">all</option></select></label>


### PR DESCRIPTION
This adds support for `--no-indent-chains`, which lets you turn this:

```js
Promise.resolve()
    .then(() => console.log("foo"))
    .then(() => console.log("bar"))
    .catch(() => console.log("boom"));
```

Into this:

```js
Promise.resolve()
.then(() => console.log("foo"))
.then(() => console.log("bar"))
.catch(() => console.log("boom"));
```

as requested by https://github.com/prettier/prettier/issues/2164.